### PR TITLE
Added PN532Reader Class for RFID Operations

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,9 @@ build_flags =
 lib_deps = 
 	bodmer/TFT_eSPI@^2.5.43
 
+	https://github.com/don/NDEF.git#1.1.0
+	https://github.com/hansmbakker/PN532.git#feature/repo-updates
+
 [env]
 monitor_speed = 115200
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,5 +1,7 @@
 [platformio]
 default_envs = 
+	cplus1_1
+	cplus2
 	cardputer
 
 [common]

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,12 +1,10 @@
 [platformio]
 default_envs = 
-	cplus1_1
-	cplus2
 	cardputer
 
 [common]
 build_flags = 
-
+	-DNFC_INTERFACE_I2C
 	
 lib_deps = 
 	bodmer/TFT_eSPI@^2.5.43

--- a/src/entities/rfid/PN532Reader.cpp
+++ b/src/entities/rfid/PN532Reader.cpp
@@ -1,0 +1,12 @@
+#include "PN532Reader.h"
+
+using namespace Entities::RFID;
+
+PN532Reader::PN532Reader()
+{
+    this->_pn532i2c = new PN532_I2C(Wire);
+    this->_nfc = new PN532(*this->_pn532i2c);
+
+    this->_nfc->begin();
+    this->_nfc->SAMConfig();
+}

--- a/src/entities/rfid/PN532Reader.cpp
+++ b/src/entities/rfid/PN532Reader.cpp
@@ -48,7 +48,7 @@ uint8_t *PN532Reader::readRegister(uint8_t reg)
 
 bool PN532Reader::writeRegister(uint8_t reg, uint8_t *value, uint8_t valueSize)
 {
-    return false;
+    return this->_nfc->mifareclassic_WriteDataBlock(reg, value);
 }
 
 bool PN532Reader::setUid(uint8_t *newUid)

--- a/src/entities/rfid/PN532Reader.cpp
+++ b/src/entities/rfid/PN532Reader.cpp
@@ -1,4 +1,6 @@
 #include "PN532Reader.h"
+#include <cstdint>
+#include <stdexcept>
 
 using namespace Entities::RFID;
 
@@ -8,5 +10,51 @@ PN532Reader::PN532Reader()
     this->_nfc = new PN532(*this->_pn532i2c);
 
     this->_nfc->begin();
+    uint32_t version = this->_nfc->getFirmwareVersion();
+    if (!version)
+    {
+        throw std::runtime_error("Didn't find PN532 board");
+    }
+
     this->_nfc->SAMConfig();
+}
+
+bool PN532Reader::isCardPresent()
+{
+    return this->_nfc->readPassiveTargetID(PN532_MIFARE_ISO14443A, this->_uid, &this->_uidLength);
+}
+
+bool PN532Reader::authenticate(uint8_t reg, uint8_t *key, uint8_t *uid)
+{
+    return this->_nfc->mifareclassic_AuthenticateBlock(uid, this->_uidLength, reg, 0, key);
+}
+
+uint8_t *PN532Reader::dumpMemory(uint8_t *uid, uint8_t *key)
+{
+    return nullptr;
+}
+
+uint8_t *PN532Reader::readSector(uint8_t sec)
+{
+    return nullptr;
+}
+
+uint8_t *PN532Reader::readRegister(uint8_t reg)
+{
+    return nullptr;
+}
+
+bool PN532Reader::writeRegister(uint8_t reg, uint8_t *value, uint8_t valueSize)
+{
+    return false;
+}
+
+bool PN532Reader::setUid(uint8_t *newUid)
+{
+    return false;
+}
+
+uint8_t *PN532Reader::getUid()
+{
+    return this->_uid;
 }

--- a/src/entities/rfid/PN532Reader.cpp
+++ b/src/entities/rfid/PN532Reader.cpp
@@ -41,7 +41,9 @@ uint8_t *PN532Reader::readSector(uint8_t sec)
 
 uint8_t *PN532Reader::readRegister(uint8_t reg)
 {
-    return nullptr;
+    uint8_t *buffer = new uint8_t[16];
+    this->_nfc->mifareclassic_ReadDataBlock(reg, buffer);
+    return buffer;
 }
 
 bool PN532Reader::writeRegister(uint8_t reg, uint8_t *value, uint8_t valueSize)

--- a/src/entities/rfid/PN532Reader.cpp
+++ b/src/entities/rfid/PN532Reader.cpp
@@ -36,7 +36,26 @@ uint8_t *PN532Reader::dumpMemory(uint8_t *uid, uint8_t *key)
 
 uint8_t *PN532Reader::readSector(uint8_t sec)
 {
-    return nullptr;
+    uint8_t reg = sec * 4;
+    uint8_t *buffer = new uint8_t[64];
+    uint8_t *regData;
+
+    for (int i = 0; i < 4; i++)
+    {
+        regData = this->readRegister(reg + i);
+        if (regData == nullptr)
+        {
+            delete[] buffer;
+            return nullptr;
+        }
+        else
+        {
+            memcpy(buffer + i * 16, regData, 16);
+            delete[] regData;
+        }
+    }
+
+    return buffer;
 }
 
 uint8_t *PN532Reader::readRegister(uint8_t reg)

--- a/src/entities/rfid/PN532Reader.cpp
+++ b/src/entities/rfid/PN532Reader.cpp
@@ -1,5 +1,6 @@
 #include "PN532Reader.h"
 #include <cstdint>
+#include <cstring>
 #include <stdexcept>
 
 using namespace Entities::RFID;
@@ -31,7 +32,28 @@ bool PN532Reader::authenticate(uint8_t reg, uint8_t *key, uint8_t *uid)
 
 uint8_t *PN532Reader::dumpMemory(uint8_t *uid, uint8_t *key)
 {
-    return nullptr;
+    uint8_t *buffer = new uint8_t[1024];
+    uint8_t *sectorData;
+
+    for (int i = 0; i < 16; i++)
+    {
+        if (!this->authenticate(i * 4, key, uid))
+        {
+            delete[] buffer;
+            return nullptr;
+        }
+        sectorData = this->readSector(i);
+        if (sectorData == nullptr)
+        {
+            delete[] buffer;
+            return nullptr;
+        }
+
+        memcpy(buffer + i * 64, sectorData, 64);
+        delete[] sectorData;
+    }
+
+    return buffer;
 }
 
 uint8_t *PN532Reader::readSector(uint8_t sec)

--- a/src/entities/rfid/PN532Reader.cpp
+++ b/src/entities/rfid/PN532Reader.cpp
@@ -92,6 +92,7 @@ bool PN532Reader::writeRegister(uint8_t reg, uint8_t *value, uint8_t valueSize)
     return this->_nfc->mifareclassic_WriteDataBlock(reg, value);
 }
 
+// TODO: Not implemented yet
 bool PN532Reader::setUid(uint8_t *newUid)
 {
     return false;

--- a/src/entities/rfid/PN532Reader.h
+++ b/src/entities/rfid/PN532Reader.h
@@ -12,11 +12,14 @@ class PN532Reader : public RfidModuleInterface
 {
   public:
     PN532Reader();
-    void dumpMemory();
-    void readSector(byte reg);
-    void readRegister(byte reg);
-    void writeRegister(byte reg, byte value);
-    void setUid(byte *newUid);
+    bool isCardPresent();
+    bool authenticate(uint8_t reg, uint8_t *key, uint8_t *uid);
+    uint8_t *dumpMemory(uint8_t *uid, uint8_t *key);
+    uint8_t *readSector(uint8_t sec);
+    uint8_t *readRegister(uint8_t reg);
+    bool writeRegister(uint8_t reg, uint8_t *value, uint8_t valueSize);
+    bool setUid(uint8_t *newUid);
+    uint8_t *getUid();
 
   private:
     PN532_I2C *_pn532i2c;

--- a/src/entities/rfid/PN532Reader.h
+++ b/src/entities/rfid/PN532Reader.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "RfidInterface.h"
+
+#include "PN532.h"
+#include "PN532_I2C.h"
+
+namespace Entities::RFID
+{
+
+class PN532Reader : public RfidModuleInterface
+{
+  public:
+    PN532Reader();
+    void dumpMemory();
+    void readSector(byte reg);
+    void readRegister(byte reg);
+    void writeRegister(byte reg, byte value);
+    void setUid(byte *newUid);
+
+  private:
+    PN532_I2C *_pn532i2c;
+    PN532 *_nfc;
+};
+
+} // namespace Entities::RFID

--- a/src/entities/rfid/PN532Reader.h
+++ b/src/entities/rfid/PN532Reader.h
@@ -4,6 +4,7 @@
 
 #include "PN532.h"
 #include "PN532_I2C.h"
+#include <cstdint>
 
 namespace Entities::RFID
 {
@@ -24,6 +25,8 @@ class PN532Reader : public RfidModuleInterface
   private:
     PN532_I2C *_pn532i2c;
     PN532 *_nfc;
+    uint8_t _uid[7];
+    uint8_t _uidLength;
 };
 
 } // namespace Entities::RFID


### PR DESCRIPTION
This pull request introduces the PN532Reader class, which provides functionalities for interacting with the PN532 RFID/NFC module. The main features include:

   - Initializing the PN532 module.
   - Checking if an RFID card is present.
   - Authenticating with the RFID card.
   - Dumping the memory content of the RFID card.
   - Reading and writing data blocks from/to the RFID card.
   - Retrieving the UID of the RFID card.

### Main Changes:

- Added `PN532Reader` class in `PN532Reader.h` and `PN532Reader.cpp`
- Implemented methods for card detection, authentication, memory dumping, sector reading, register reading and 
- Included placeholder method setUid (not implemented yet).