### PR TITLE
Added Mfrc522Reader Class for RFID Operations

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,6 +10,7 @@ build_flags =
 	
 lib_deps = 
 	bodmer/TFT_eSPI@^2.5.43
+	kkloesener/MFRC522_I2C@^1.0
 
 [env]
 monitor_speed = 115200

--- a/src/entities/rfid/Mfrc522Reader.cpp
+++ b/src/entities/rfid/Mfrc522Reader.cpp
@@ -1,35 +1,77 @@
 #include "Mfrc522Reader.h"
+#include <cstdint>
 
 using namespace Entities::RFID;
 
 Mfrc522Reader::Mfrc522Reader()
 {
+    this->_mfrc522 = new MFRC522_I2C(0x28, 0);
+    this->_mfrc522->PCD_Init();
 }
 
 bool Mfrc522Reader::isCardPresent()
 {
+    return !this->_mfrc522->PICC_IsNewCardPresent() || !this->_mfrc522->PICC_ReadCardSerial();
 }
 
-bool Mfrc522Reader::authenticate(uint8_t reg, uint8_t key, uint8_t uid)
+bool Mfrc522Reader::authenticate(uint8_t reg, uint8_t *key, uint8_t *uid)
+{
+    MFRC522_I2C::MIFARE_Key _key;
+    for (int i = 0; i < 6; i++)
+    {
+        _key.keyByte[i] = *(key + i);
+    }
+
+    uint8_t status =
+        this->_mfrc522->PCD_Authenticate(MFRC522_I2C::PICC_CMD_MF_AUTH_KEY_A, reg, &_key, &(this->_mfrc522->uid));
+
+    if (status != MFRC522_I2C::STATUS_OK)
+    {
+        Serial.print(F("Authentication failed: "));
+        Serial.println(this->_mfrc522->GetStatusCodeName(status));
+        return 0;
+    }
+    return 1;
+}
+
+uint8_t Mfrc522Reader::dumpMemory(uint8_t *uid)
 {
 }
 
-uint8_t Mfrc522Reader::dumpMemory(uint8_t uid)
+uint8_t *Mfrc522Reader::readSector(uint8_t reg)
 {
 }
 
-uint8_t Mfrc522Reader::readSector(uint8_t reg)
+uint8_t *Mfrc522Reader::readRegister(uint8_t reg)
 {
+    uint8_t len = 18;
+    static uint8_t buffer[18];
+    uint8_t status = this->_mfrc522->MIFARE_Read(reg, buffer, &len);
+
+    if (status != MFRC522_I2C::STATUS_OK)
+    {
+        Serial.print(F("Reading failed: "));
+        Serial.println(this->_mfrc522->GetStatusCodeName(status));
+        return nullptr;
+    }
+    return buffer;
 }
 
-uint8_t Mfrc522Reader::readRegister(uint8_t reg)
-{
-}
-
-bool Mfrc522Reader::writeRegister(uint8_t reg, uint8_t value)
+bool Mfrc522Reader::writeRegister(uint8_t reg, uint8_t *value, uint8_t valueSize)
 {
 }
 
 bool Mfrc522Reader::setUid(uint8_t *newUid)
 {
+}
+
+uint8_t *Mfrc522Reader::getUid()
+{
+    return this->_mfrc522->uid.uidByte;
+}
+
+void Mfrc522Reader::stop()
+{
+    this->_mfrc522->PICC_HaltA();
+    this->_mfrc522->PCD_StopCrypto1();
 }

--- a/src/entities/rfid/Mfrc522Reader.cpp
+++ b/src/entities/rfid/Mfrc522Reader.cpp
@@ -1,5 +1,7 @@
 #include "Mfrc522Reader.h"
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
 
 using namespace Entities::RFID;
 
@@ -29,17 +31,43 @@ bool Mfrc522Reader::authenticate(uint8_t reg, uint8_t *key, uint8_t *uid)
     {
         Serial.print(F("Authentication failed: "));
         Serial.println(this->_mfrc522->GetStatusCodeName(status));
-        return 0;
+        return false;
     }
-    return 1;
+    return true;
 }
 
 uint8_t Mfrc522Reader::dumpMemory(uint8_t *uid)
 {
 }
 
-uint8_t *Mfrc522Reader::readSector(uint8_t reg)
+uint8_t *Mfrc522Reader::readSector(uint8_t sec)
 {
+    uint8_t reg = sec * 4;
+    uint8_t *buffer = (uint8_t *)malloc(64);
+    uint8_t *regData;
+
+    if (buffer == nullptr)
+    {
+        Serial.print("Error to alloc buffer");
+        return nullptr;
+    }
+
+    for (uint8_t i = 0; i < 4; i++)
+    {
+        regData = this->readRegister(reg + i);
+        if (regData == nullptr)
+        {
+            Serial.print("Reading register failed: ");
+            Serial.println(i);
+            return nullptr;
+        }
+        else
+        {
+            memcpy(buffer + (i * 16), regData, 16);
+        }
+    }
+
+    return buffer;
 }
 
 uint8_t *Mfrc522Reader::readRegister(uint8_t reg)

--- a/src/entities/rfid/Mfrc522Reader.cpp
+++ b/src/entities/rfid/Mfrc522Reader.cpp
@@ -24,7 +24,7 @@ bool Mfrc522Reader::authenticate(uint8_t reg, uint8_t *key, uint8_t *uid)
         _key.keyByte[i] = *(key + i);
     }
 
-    Serial.println("authenticate:: Autenticando o registrador " + String(reg));
+    // Serial.println("authenticate:: Autenticando o registrador " + String(reg));
 
     uint8_t status =
         this->_mfrc522->PCD_Authenticate(MFRC522_I2C::PICC_CMD_MF_AUTH_KEY_A, reg, &_key, &(this->_mfrc522->uid));
@@ -36,7 +36,7 @@ bool Mfrc522Reader::authenticate(uint8_t reg, uint8_t *key, uint8_t *uid)
         return false;
     }
 
-    Serial.println("authenticate:: Registrador " + String(reg) + " autenticado!");
+    // Serial.println("authenticate:: Registrador " + String(reg) + " autenticado!");
     return true;
 }
 
@@ -50,7 +50,7 @@ uint8_t *Mfrc522Reader::dumpMemory(uint8_t *uid, uint8_t *key)
         return nullptr;
     }
 
-    Serial.println("dumpMemory:: Lendo a memoria!");
+    // Serial.println("dumpMemory:: Lendo a memoria!");
 
     for (uint8_t i = 0; i < 16; i++)
     {
@@ -73,7 +73,7 @@ uint8_t *Mfrc522Reader::dumpMemory(uint8_t *uid, uint8_t *key)
         }
     }
 
-    Serial.println("dumpMemory:: memoria lida!");
+    // Serial.println("dumpMemory:: memoria lida!");
     return buffer;
 }
 
@@ -89,7 +89,7 @@ uint8_t *Mfrc522Reader::readSector(uint8_t sec)
         return nullptr;
     }
 
-    Serial.println("readSector:: Lendo o setor " + String(sec));
+    // Serial.println("readSector:: Lendo o setor " + String(sec));
 
     for (uint8_t i = 0; i < 4; i++)
     {
@@ -105,7 +105,7 @@ uint8_t *Mfrc522Reader::readSector(uint8_t sec)
         }
     }
 
-    Serial.println("readSector:: Setor " + String(sec) + " lido!");
+    // Serial.println("readSector:: Setor " + String(sec) + " lido!");
     return buffer;
 }
 
@@ -114,7 +114,7 @@ uint8_t *Mfrc522Reader::readRegister(uint8_t reg)
     uint8_t len = 18;
     static uint8_t buffer[18];
 
-    Serial.println("readRegister:: Lendo o registrador " + String(reg));
+    // Serial.println("readRegister:: Lendo o registrador " + String(reg));
     uint8_t status = this->_mfrc522->MIFARE_Read(reg, buffer, &len);
 
     if (status != MFRC522_I2C::STATUS_OK)
@@ -124,7 +124,7 @@ uint8_t *Mfrc522Reader::readRegister(uint8_t reg)
         return nullptr;
     }
 
-    Serial.println("readRegister:: Registrador " + String(reg) + " lido!");
+    // Serial.println("readRegister:: Registrador " + String(reg) + " lido!");
     return buffer;
 }
 

--- a/src/entities/rfid/Mfrc522Reader.cpp
+++ b/src/entities/rfid/Mfrc522Reader.cpp
@@ -1,0 +1,35 @@
+#include "Mfrc522Reader.h"
+
+using namespace Entities::RFID;
+
+Mfrc522Reader::Mfrc522Reader()
+{
+}
+
+bool Mfrc522Reader::isCardPresent()
+{
+}
+
+bool Mfrc522Reader::authenticate(uint8_t reg, uint8_t key, uint8_t uid)
+{
+}
+
+uint8_t Mfrc522Reader::dumpMemory(uint8_t uid)
+{
+}
+
+uint8_t Mfrc522Reader::readSector(uint8_t reg)
+{
+}
+
+uint8_t Mfrc522Reader::readRegister(uint8_t reg)
+{
+}
+
+bool Mfrc522Reader::writeRegister(uint8_t reg, uint8_t value)
+{
+}
+
+bool Mfrc522Reader::setUid(uint8_t *newUid)
+{
+}

--- a/src/entities/rfid/Mfrc522Reader.cpp
+++ b/src/entities/rfid/Mfrc522Reader.cpp
@@ -130,10 +130,19 @@ uint8_t *Mfrc522Reader::readRegister(uint8_t reg)
 
 bool Mfrc522Reader::writeRegister(uint8_t reg, uint8_t *value, uint8_t valueSize)
 {
+    uint8_t status = this->_mfrc522->MIFARE_Write(reg, value, valueSize);
+    if (status != MFRC522_I2C::STATUS_OK)
+    {
+        Serial.print(F("MIFARE_Write() failed: "));
+        Serial.println(this->_mfrc522->GetStatusCodeName(status));
+        return false;
+    }
+    return true;
 }
 
 bool Mfrc522Reader::setUid(uint8_t *newUid)
 {
+    return this->_mfrc522->MIFARE_SetUid(newUid, (uint8_t)4, true);
 }
 
 uint8_t *Mfrc522Reader::getUid()

--- a/src/entities/rfid/Mfrc522Reader.cpp
+++ b/src/entities/rfid/Mfrc522Reader.cpp
@@ -150,7 +150,7 @@ uint8_t *Mfrc522Reader::getUid()
     return this->_mfrc522->uid.uidByte;
 }
 
-void Mfrc522Reader::stop()
+void Mfrc522Reader::halt()
 {
     this->_mfrc522->PICC_HaltA();
     this->_mfrc522->PCD_StopCrypto1();

--- a/src/entities/rfid/Mfrc522Reader.cpp
+++ b/src/entities/rfid/Mfrc522Reader.cpp
@@ -24,20 +24,57 @@ bool Mfrc522Reader::authenticate(uint8_t reg, uint8_t *key, uint8_t *uid)
         _key.keyByte[i] = *(key + i);
     }
 
+    Serial.println("authenticate:: Autenticando o registrador " + String(reg));
+
     uint8_t status =
         this->_mfrc522->PCD_Authenticate(MFRC522_I2C::PICC_CMD_MF_AUTH_KEY_A, reg, &_key, &(this->_mfrc522->uid));
 
     if (status != MFRC522_I2C::STATUS_OK)
     {
-        Serial.print(F("Authentication failed: "));
+        Serial.print(F("authenticate:: Authentication failed: "));
         Serial.println(this->_mfrc522->GetStatusCodeName(status));
         return false;
     }
+
+    Serial.println("authenticate:: Registrador " + String(reg) + " autenticado!");
     return true;
 }
 
-uint8_t Mfrc522Reader::dumpMemory(uint8_t *uid)
+uint8_t *Mfrc522Reader::dumpMemory(uint8_t *uid, uint8_t *key)
 {
+    uint8_t *buffer = (uint8_t *)malloc(1024);
+
+    if (buffer == nullptr)
+    {
+        Serial.print("dumpMemory:: Error to alloc buffer");
+        return nullptr;
+    }
+
+    Serial.println("dumpMemory:: Lendo a memoria!");
+
+    for (uint8_t i = 0; i < 16; i++)
+    {
+        if (!this->authenticate(i * 4, key, uid))
+        {
+            free(buffer);
+            return nullptr;
+        }
+
+        uint8_t *partial_buffer = this->readSector(i);
+        if (partial_buffer != nullptr)
+        {
+            memcpy(buffer + (64 * i), partial_buffer, 64);
+            free(partial_buffer);
+        }
+        else
+        {
+            free(buffer);
+            return nullptr;
+        }
+    }
+
+    Serial.println("dumpMemory:: memoria lida!");
+    return buffer;
 }
 
 uint8_t *Mfrc522Reader::readSector(uint8_t sec)
@@ -48,17 +85,18 @@ uint8_t *Mfrc522Reader::readSector(uint8_t sec)
 
     if (buffer == nullptr)
     {
-        Serial.print("Error to alloc buffer");
+        Serial.print("readSector:: Error to alloc buffer");
         return nullptr;
     }
+
+    Serial.println("readSector:: Lendo o setor " + String(sec));
 
     for (uint8_t i = 0; i < 4; i++)
     {
         regData = this->readRegister(reg + i);
         if (regData == nullptr)
         {
-            Serial.print("Reading register failed: ");
-            Serial.println(i);
+            free(buffer);
             return nullptr;
         }
         else
@@ -67,6 +105,7 @@ uint8_t *Mfrc522Reader::readSector(uint8_t sec)
         }
     }
 
+    Serial.println("readSector:: Setor " + String(sec) + " lido!");
     return buffer;
 }
 
@@ -74,14 +113,18 @@ uint8_t *Mfrc522Reader::readRegister(uint8_t reg)
 {
     uint8_t len = 18;
     static uint8_t buffer[18];
+
+    Serial.println("readRegister:: Lendo o registrador " + String(reg));
     uint8_t status = this->_mfrc522->MIFARE_Read(reg, buffer, &len);
 
     if (status != MFRC522_I2C::STATUS_OK)
     {
-        Serial.print(F("Reading failed: "));
+        Serial.print("Reading register" + String(reg) + " failed: ");
         Serial.println(this->_mfrc522->GetStatusCodeName(status));
         return nullptr;
     }
+
+    Serial.println("readRegister:: Registrador " + String(reg) + " lido!");
     return buffer;
 }
 

--- a/src/entities/rfid/Mfrc522Reader.h
+++ b/src/entities/rfid/Mfrc522Reader.h
@@ -14,7 +14,7 @@ class Mfrc522Reader : public RfidModuleInterface
     bool isCardPresent();
     bool authenticate(uint8_t reg, uint8_t *key, uint8_t *uid);
     uint8_t dumpMemory(uint8_t *uid);
-    uint8_t *readSector(uint8_t reg);
+    uint8_t *readSector(uint8_t sec);
     uint8_t *readRegister(uint8_t reg);
     bool writeRegister(uint8_t reg, uint8_t *value, uint8_t valueSize);
     bool setUid(uint8_t *newUid);

--- a/src/entities/rfid/Mfrc522Reader.h
+++ b/src/entities/rfid/Mfrc522Reader.h
@@ -19,7 +19,7 @@ class Mfrc522Reader : public RfidModuleInterface
     bool writeRegister(uint8_t reg, uint8_t *value, uint8_t valueSize);
     bool setUid(uint8_t *newUid);
     uint8_t *getUid();
-    void stop();
+    void halt();
 
   private:
     MFRC522_I2C *_mfrc522;

--- a/src/entities/rfid/Mfrc522Reader.h
+++ b/src/entities/rfid/Mfrc522Reader.h
@@ -13,7 +13,7 @@ class Mfrc522Reader : public RfidModuleInterface
     Mfrc522Reader();
     bool isCardPresent();
     bool authenticate(uint8_t reg, uint8_t *key, uint8_t *uid);
-    uint8_t dumpMemory(uint8_t *uid);
+    uint8_t *dumpMemory(uint8_t *uid, uint8_t *key);
     uint8_t *readSector(uint8_t sec);
     uint8_t *readRegister(uint8_t reg);
     bool writeRegister(uint8_t reg, uint8_t *value, uint8_t valueSize);

--- a/src/entities/rfid/Mfrc522Reader.h
+++ b/src/entities/rfid/Mfrc522Reader.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "RfidInterface.h"
+#include <WString.h>
+
+namespace Entities::RFID
+{
+class Mfrc522Reader : public RfidModuleInterface
+{
+  public:
+    Mfrc522Reader();
+    bool isCardPresent();
+    bool authenticate(uint8_t reg, uint8_t key, uint8_t uid);
+    uint8_t dumpMemory(uint8_t uid);
+    uint8_t readSector(uint8_t reg);
+    uint8_t readRegister(uint8_t reg);
+    bool writeRegister(uint8_t reg, uint8_t value);
+    bool setUid(uint8_t *newUid);
+
+  private:
+};
+
+} // namespace Entities::RFID

--- a/src/entities/rfid/Mfrc522Reader.h
+++ b/src/entities/rfid/Mfrc522Reader.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "MFRC522_I2C.h"
 #include "RfidInterface.h"
 #include <WString.h>
+#include <cstdint>
 
 namespace Entities::RFID
 {
@@ -10,14 +12,17 @@ class Mfrc522Reader : public RfidModuleInterface
   public:
     Mfrc522Reader();
     bool isCardPresent();
-    bool authenticate(uint8_t reg, uint8_t key, uint8_t uid);
-    uint8_t dumpMemory(uint8_t uid);
-    uint8_t readSector(uint8_t reg);
-    uint8_t readRegister(uint8_t reg);
-    bool writeRegister(uint8_t reg, uint8_t value);
+    bool authenticate(uint8_t reg, uint8_t *key, uint8_t *uid);
+    uint8_t dumpMemory(uint8_t *uid);
+    uint8_t *readSector(uint8_t reg);
+    uint8_t *readRegister(uint8_t reg);
+    bool writeRegister(uint8_t reg, uint8_t *value, uint8_t valueSize);
     bool setUid(uint8_t *newUid);
+    uint8_t *getUid();
+    void stop();
 
   private:
+    MFRC522_I2C *_mfrc522;
 };
 
 } // namespace Entities::RFID

--- a/src/entities/rfid/RfidInterface.h
+++ b/src/entities/rfid/RfidInterface.h
@@ -13,7 +13,7 @@ class RfidModuleInterface
     }
     virtual bool isCardPresent() = 0;
     virtual bool authenticate(uint8_t reg, uint8_t *key, uint8_t *uid) = 0;
-    virtual uint8_t dumpMemory(uint8_t *uid) = 0;
+    virtual uint8_t *dumpMemory(uint8_t *uid, uint8_t *key) = 0;
     virtual uint8_t *readSector(uint8_t sec) = 0;
     virtual uint8_t *readRegister(uint8_t reg) = 0;
     virtual bool writeRegister(uint8_t reg, uint8_t *value, uint8_t valueSize) = 0;

--- a/src/entities/rfid/RfidInterface.h
+++ b/src/entities/rfid/RfidInterface.h
@@ -14,7 +14,7 @@ class RfidModuleInterface
     virtual bool isCardPresent() = 0;
     virtual bool authenticate(uint8_t reg, uint8_t *key, uint8_t *uid) = 0;
     virtual uint8_t dumpMemory(uint8_t *uid) = 0;
-    virtual uint8_t *readSector(uint8_t reg) = 0;
+    virtual uint8_t *readSector(uint8_t sec) = 0;
     virtual uint8_t *readRegister(uint8_t reg) = 0;
     virtual bool writeRegister(uint8_t reg, uint8_t *value, uint8_t valueSize) = 0;
     virtual bool setUid(uint8_t *newUid) = 0;


### PR DESCRIPTION
This pull request introduces the Mfrc522Reader class, which provides functionalities for interacting with the MFRC522 RFID module. The main features 

- Initializing the MFRC522 module.
- Checking if an RFID card is 
- Authenticating with the RFID 
- Dumping the memory content of the RFID card.
- Reading and writing data blocks from/to the RFID card.
- Retrieving and setting the UID of the RFID card.
- Halting the RFID card.

### Main Changes:

- Added `Mfrc522Reader` class in `Mfrc522Reader.h` and `Mfrc522Reader.cpp`.
- Implemented methods for card detection, authentication, memory dumping, sector reading, register reading and writing, setting UID, and halting the card.